### PR TITLE
Use mz/fs for node 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('node-forge'), require('path'), require('fs')) :
-	typeof define === 'function' && define.amd ? define(['exports', 'node-forge', 'path', 'fs'], factory) :
-	(factory((global['selfsigned-ca'] = {}),global['node-forge'],global.path,global.fs));
-}(this, (function (exports,forge,path,_fs) { 'use strict';
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('node-forge'), require('path'), require('fs'), require('mz/fs')) :
+	typeof define === 'function' && define.amd ? define(['exports', 'node-forge', 'path', 'fs', 'mz/fs'], factory) :
+	(factory((global['selfsigned-ca'] = {}),global['node-forge'],global.path,global.fs,global.mzfs));
+}(this, (function (exports,forge,path,_fs,mzfs) { 'use strict';
 
 	forge = forge && forge.hasOwnProperty('default') ? forge['default'] : forge;
 	path = path && path.hasOwnProperty('default') ? path['default'] : path;
 	_fs = _fs && _fs.hasOwnProperty('default') ? _fs['default'] : _fs;
+	mzfs = mzfs && mzfs.hasOwnProperty('default') ? mzfs['default'] : mzfs;
 
-	var fs = _fs.promises;
-
+	var fs = _fs.promises || mzfs;
 
 	const defaultOptions = {
 		days: 365,
@@ -241,7 +241,7 @@
 			if (this._certificate) return this._certificate
 			if (this.cert) return this._certificate = forge.pki.certificateFromPem(this.cert)
 		}
-		
+
 		set privateKey(privateKey)   {this._privateKey  = privateKey;}
 		set publicKey(publicKey)     {this._publicKey   = publicKey;}
 		set certificate(certificate) {this._certificate = certificate;}

--- a/index.mjs
+++ b/index.mjs
@@ -1,8 +1,9 @@
 import forge from 'node-forge'
 import path from 'path'
 import _fs from 'fs'
-var fs = _fs.promises
+import mzfs from 'mz/fs';
 
+var fs = _fs.promises || mzfs
 
 const defaultOptions = {
 	days: 365,
@@ -234,7 +235,7 @@ export class Cert {
 		if (this._certificate) return this._certificate
 		if (this.cert) return this._certificate = forge.pki.certificateFromPem(this.cert)
 	}
-	
+
 	set privateKey(privateKey)   {this._privateKey  = privateKey}
 	set publicKey(publicKey)     {this._publicKey   = publicKey}
 	set certificate(certificate) {this._certificate = certificate}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "rollup-plugin-notify": "^1.0.3"
   },
   "dependencies": {
+    "mz": "^2.7.0",
     "node-forge": "^0.7.5"
   }
 }


### PR DESCRIPTION
For the node version (e.g. node 8)  which not support file promises, we can use mz instead. 